### PR TITLE
Refresh igra-token page with live stats and updated content

### DIFF
--- a/src/Components/AboutBenefits/AboutBenefits.tsx
+++ b/src/Components/AboutBenefits/AboutBenefits.tsx
@@ -22,7 +22,7 @@ const benefitsList: Benefit[] = [
         {'$IGRA governs Igra\'s security-critical parameters via Igra DAO, including attestation rules, rewards and penalties calibration, bridge configuration and updates, and allocation of ecosystem grants.'}
       </>
     ),
-    to: '',
+    to: 'https://governance.igralabs.com/',
   },
   {
     iconName: 'flag',

--- a/src/pages/IgraTokenPage/IgraTokenPage.module.scss
+++ b/src/pages/IgraTokenPage/IgraTokenPage.module.scss
@@ -2,6 +2,104 @@
     max-width: 1200px;
     margin: 80px auto 0;
 
+    .heroRow {
+        display: grid;
+        grid-template-columns: 1fr 440px;
+        gap: 48px;
+        align-items: start;
+
+        @media screen and (max-width: $tablet) {
+            grid-template-columns: 1fr;
+            gap: 32px;
+        }
+    }
+
+    .heroContent {
+        min-width: 0;
+    }
+
+    .statsPanel {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 20px;
+        padding: 32px 36px;
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        position: sticky;
+        top: 100px;
+
+        @media screen and (max-width: $tablet) {
+            position: static;
+            padding: 24px 24px;
+        }
+    }
+
+    .statsPanelTitle {
+        font-family: $font-secondary;
+        font-size: 28px;
+        font-weight: 400;
+        color: #FFFFFF;
+        margin: 0 0 8px;
+    }
+
+    .statsPanelTitleLink {
+        color: #6BD1C3;
+        text-decoration: none;
+        transition: text-decoration 0.2s;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
+    .statItem {
+        display: flex;
+        justify-content: space-between;
+        align-items: baseline;
+        gap: 16px;
+        padding: 14px 0;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+
+        &:first-of-type {
+            border-top: none;
+        }
+    }
+
+    .statLabel {
+        font-family: $font;
+        font-size: 14px;
+        color: rgba(255, 255, 255, 0.6);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+    }
+
+    .statValue {
+        font-family: $font-secondary;
+        font-size: 22px;
+        font-weight: 500;
+        color: #FFFFFF;
+        white-space: nowrap;
+    }
+
+    .statValueSecondary {
+        font-family: $font;
+        font-size: 14px;
+        font-weight: 400;
+        color: rgba(255, 255, 255, 0.55);
+        margin-left: 4px;
+    }
+
+    .inlineLink {
+        color: #6BD1C3;
+        text-decoration: none;
+        transition: text-decoration 0.2s;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+
     .title {
         margin-bottom: 30px;
         font-family: $font-secondary;

--- a/src/pages/IgraTokenPage/IgraTokenPage.tsx
+++ b/src/pages/IgraTokenPage/IgraTokenPage.tsx
@@ -1,9 +1,7 @@
-import { FC } from "react"
-import { Link } from "react-router-dom"
+import { FC, useEffect, useState } from "react"
 
 import { AboutBenefits, PageLayout } from "~/Components"
-import { to } from "~/shared/lib"
-import { Flex } from "~/shared/ui"
+import { Flex, Icon } from "~/shared/ui"
 
 import tokenDistributionChart from './assets/token-distribution-chart.png'
 import classes from './IgraTokenPage.module.scss'
@@ -41,28 +39,202 @@ const distributionItems = [
   },
 ]
 
+const TOKEN_API = 'https://apis.igralabs.com/igra-token'
+const PRICE_API = 'https://apis.igralabs.com/twap/price/0x093d77d397F8acCbaee0820345E9E700B1233cD1'
+const RPC_URL = 'https://rpc.igralabs.com:8545'
+const ATTESTATION_DIAMOND = '0xc24Df70E408739aeF6bF594fd41db4632dF49188'
+// Function selector for getTotalStats()
+const GET_TOTAL_STATS_SELECTOR = '0xfc5cbf1d'
+
+interface TokenStats {
+  maxSupply?: number
+  totalSupply?: number
+  totalStaked?: number
+  priceUsd?: number
+  priceIkas?: number
+}
+
+function formatNumber(n: number | undefined): string {
+  if (n === undefined) return '—'
+  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(2)}B`
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(2)}K`
+  return n.toFixed(0)
+}
+
+function formatPrice(n: number | undefined): string {
+  if (n === undefined) return '—'
+  return `$${n.toFixed(6)}`
+}
+
+async function fetchTokenStats(): Promise<TokenStats> {
+  const result: TokenStats = {}
+
+  // Fetch supply data
+  try {
+    const res = await fetch(TOKEN_API)
+    if (res.ok) {
+      const data = await res.json()
+      result.maxSupply = parseFloat(data.maxSupply)
+      result.totalSupply = parseFloat(data.totalSupply)
+    }
+  } catch { /* ignore */ }
+
+  // Fetch price
+  try {
+    const res = await fetch(PRICE_API)
+    if (res.ok) {
+      const data = await res.json()
+      result.priceUsd = data.price_usd
+      result.priceIkas = data.price_ikas
+    }
+  } catch { /* ignore */ }
+
+  // Fetch total staked from Attestation Diamond contract
+  try {
+    const res = await fetch(RPC_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'eth_call',
+        params: [{ to: ATTESTATION_DIAMOND, data: GET_TOTAL_STATS_SELECTOR }, 'latest'],
+      }),
+    })
+    if (res.ok) {
+      const json = await res.json()
+      const hex: string = json.result
+      if (hex && hex.length >= 2 + 64 * 3) {
+        // Parse tuple: stakedAmount (uint256), penalties (uint256), slashes (uint256), ...
+        const staked = BigInt('0x' + hex.slice(2, 66))
+        const penalties = BigInt('0x' + hex.slice(66, 130))
+        const slashes = BigInt('0x' + hex.slice(130, 194))
+        const effective = staked - penalties - slashes
+        result.totalStaked = Number(effective) / 1e18
+      }
+    }
+  } catch { /* ignore */ }
+
+  return result
+}
 
 export const IgraTokenPage: FC = () => {
+  const [stats, setStats] = useState<TokenStats>({})
+
+  useEffect(() => {
+    let cancelled = false
+    fetchTokenStats().then(s => {
+      if (!cancelled) setStats(s)
+    })
+    return () => { cancelled = true }
+  }, [])
+
   return (
     <PageLayout hideBg>
       <Flex flexDirection='column' gap={40} className={classes.root}>
-        <Flex flexDirection='column' gap={30}>
-          <div>
-            <h1 className={classes.title}>What is $IGRA?</h1>
-            <h2 className={classes.subtitle}>KAS for inclusion. $IGRA for execution.</h2>
+        <div className={classes.heroRow}>
+          <Flex flexDirection='column' gap={30} className={classes.heroContent}>
+            <div>
+              <h2 className={classes.subtitle}>KAS for inclusion. $IGRA for execution.</h2>
+            </div>
+            <p className={classes.description}>
+              <span className={classes.boldText}>$IGRA</span>
+              {' secures the Igra Network and governs the protocol. Fixed supply. Demand grows with network usage.'}
+              <br />
+              {'Fair launched via '}
+              <a
+                href="https://www.zealousswap.com/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={classes.inlineLink}
+              >
+                Zealous Swap ZAP
+              </a>
+              {', a fair onchain auction mechanism. No hidden actors, no frontrunning, no undisclosed allocations, no random airdrops.'}
+              <br /><br />
+              <a
+                href="https://igra-labs.gitbook.io/igralabs-docs"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={classes.inlineLink}
+              >
+                Documentation <Icon name='arrowTopRight' size={10} />
+              </a>
+              <br />
+              <a
+                href="https://github.com/IgraLabs/research/blob/main/igra-litepaper-v1.0.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={classes.inlineLink}
+              >
+                Litepaper <Icon name='arrowTopRight' size={10} />
+              </a>
+            </p>
+            <div className={classes.participateSection}>
+              <h3 className={classes.participateTitle}>
+                Now trading:{' '}
+                <a
+                  href="https://app.zealousswap.com/swap"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={classes.contactLink}
+                >
+                  Zealous Swap
+                </a>
+              </h3>
+            </div>
+          </Flex>
+
+          <div className={classes.statsPanel}>
+            <h3 className={classes.statsPanelTitle}>
+              <a
+                href="https://explorer.igralabs.com/token/0x093d77d397F8acCbaee0820345E9E700B1233cD1"
+                target="_blank"
+                rel="noopener noreferrer"
+                className={classes.statsPanelTitleLink}
+              >
+                $IGRA
+              </a>
+              {' Stats'}
+            </h3>
+            <div className={classes.statItem}>
+              <span className={classes.statLabel}>Price</span>
+              <span className={classes.statValue}>
+                {formatPrice(stats.priceUsd)}
+                {stats.priceIkas !== undefined && (
+                  <span className={classes.statValueSecondary}> ({stats.priceIkas.toFixed(4)} iKAS)</span>
+                )}
+              </span>
+            </div>
+            <div className={classes.statItem}>
+              <span className={classes.statLabel}>Max Supply</span>
+              <span className={classes.statValue}>{formatNumber(stats.maxSupply)}</span>
+            </div>
+            <div className={classes.statItem}>
+              <span className={classes.statLabel}>Total Supply</span>
+              <span className={classes.statValue}>{formatNumber(stats.totalSupply)}</span>
+            </div>
+            <div className={classes.statItem}>
+              <span className={classes.statLabel}>FDV</span>
+              <span className={classes.statValue}>
+                {stats.priceUsd && stats.maxSupply
+                  ? `$${formatNumber(stats.priceUsd * stats.maxSupply)}`
+                  : '—'}
+              </span>
+            </div>
+            <div className={classes.statItem}>
+              <span className={classes.statLabel}>Total Staked</span>
+              <span className={classes.statValue}>
+                {formatNumber(stats.totalStaked)}
+                {stats.totalStaked !== undefined && (
+                  <span className={classes.statValueSecondary}> IGRA</span>
+                )}
+              </span>
+            </div>
           </div>
-          <p className={classes.description}>
-            {'KAS handles sequencing, $IGRA secures execution.'}
-            <br /><br />
-            <span className={classes.boldText}>$IGRA</span>
-            {' secures the Igra Network and governs the protocol. Fixed supply. Demand grows with network usage.'}
-            <br />
-            {'Fair launch via fair onchain auction mechanism. No hidden actors, no frontrunning, no undisclosed allocations, no random airdrops.'}
-          </p>
-        </Flex>
-        <div className={classes.participateSection}>
-          <h3 className={classes.participateTitle}>Token sale is on 26th of March! <Link to={to.publicAuction()} className={classes.contactLink}>Learn more</Link></h3>
         </div>
+
         <AboutBenefits />
         <div className={classes.tokenDistribution}>
           <h2 className={classes.distributionTitle}>Token distribution</h2>


### PR DESCRIPTION
## Summary
- New live **$IGRA Stats** panel (right side, sticky): Price (USD + iKAS), Max Supply, Total Supply, FDV, Total Staked
- Price & supply from `apis.igralabs.com`, staked from `getTotalStats()` on Attestation Diamond
- Governance card now links to `governance.igralabs.com`
- Removed "What is $IGRA?" title and "Token sale is on 26th of March" line
- Updated description: past tense, "Fair launched via Zealous Swap ZAP"
- Added "Now trading: Zealous Swap" link
- Added Documentation and Litepaper inline links with arrow icons
- $IGRA in stats panel title links to explorer token page

## Test plan
- [ ] Stats panel loads live values
- [ ] All links open in new tabs
- [ ] Responsive layout stacks on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)