### PR TITLE
Remove 'Token sale live' from og:description

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <style lang="sass" type="text/sass" scoped></style>
     <title>Igra Labs</title>
     <meta property="og:title" content="Igra Network — EVM on Kaspa BlockDAG" />
-    <meta property="og:description" content="Ethereum-compatible programmable layer on Kaspa's BlockDAG proof-of-work. Token sale live." />
+    <meta property="og:description" content="Ethereum-compatible programmable layer on Kaspa's BlockDAG proof-of-work." />
     <meta property="og:image" content="https://igralabs.com/og-image.jpg" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />


### PR DESCRIPTION
## Summary
- og:description updated: removed "Token sale live." suffix

## Test plan
- [ ] After deploy, refresh Telegram preview via @WebpageBot

🤖 Generated with [Claude Code](https://claude.com/claude-code)