### PR TITLE
Add KAS small icon to public media

### DIFF
--- a/public/media/icons/kas-small-icon.svg
+++ b/public/media/icons/kas-small-icon.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1000 1000">
+  <!-- Generator: Adobe Illustrator 29.8.1, SVG Export Plug-In . SVG Version: 2.1.1 Build 2)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #097d6a;
+      }
+
+      .st1 {
+        fill: #fff;
+      }
+    </style>
+  </defs>
+  <polygon class="st0" points="924.4 745 924.4 255 500 10 75.6 255 75.6 745 500 990 924.4 745"/>
+  <g id="Layer_2">
+    <path class="st1" d="M562.9,811.5l-111-16.4,31.5-213.9-231.7,178.2-68.5-89.1,202.9-156.3-202.9-156.3,68.5-89.1,231.7,178.2-31.5-213.9,111-16.4,43.8,297.5-43.8,297.5Z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add KAS small icon SVG at `/media/icons/kas-small-icon.svg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)