### PR TITLE
Claim page: update giveaway dates to 3 August 2026

### DIFF
--- a/src/pages/TangemClaimPage/legalContent.tsx
+++ b/src/pages/TangemClaimPage/legalContent.tsx
@@ -24,7 +24,7 @@ export const GIVEAWAY_RULES_TITLE = 'Igra × Tangem ZAP Wallet Giveaway Rules'
 
 export const GiveawayRules: FC = () => (
   <>
-    <p className={classes.effective}>Effective date: 1 August 2026</p>
+    <p className={classes.effective}>Effective date: 3 August 2026</p>
 
     <h3>1. Organizer and purpose</h3>
     <p>
@@ -80,7 +80,7 @@ export const GiveawayRules: FC = () => (
 
     <h3>4. Registration</h3>
     <p>
-      Registration opens on <strong>1 August 2026</strong> and closes on{' '}
+      Registration opens on <strong>3 August 2026</strong> and closes on{' '}
       <strong>15 August 2026 at 23:59 UTC</strong>.
     </p>
     <p>To register, a participant must:</p>
@@ -194,7 +194,7 @@ export const PRIVACY_NOTICE_TITLE = 'Igra × Tangem ZAP Wallet Giveaway Privacy 
 
 export const PrivacyNotice: FC = () => (
   <>
-    <p className={classes.effective}>Effective date: 1 August 2026</p>
+    <p className={classes.effective}>Effective date: 3 August 2026</p>
     <p>The controller responsible for the Giveaway is:</p>
     <OrgAddress />
     <p>


### PR DESCRIPTION
Updates the giveaway dates on the `/tangem-claim` legal documents from **1 August 2026** to **3 August 2026**:

- **Effective date** on the Giveaway Rules and Privacy Notice → 3 August 2026
- **Registration opens** date in the Rules → 3 August 2026

The **deadline** (15 August 2026, 23:59 UTC) is unchanged.

Small copy-only change in `legalContent.tsx` (3 lines). `yarn build` passes.

> Note: these dates should match what the backend / eligibility snapshot actually use — confirm consistency before the giveaway goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)