### PR TITLE
Claim page: Tangem prize is a 2-card set (was 3-card)

### DIFF
--- a/src/pages/TangemClaimPage/TangemClaimPage.tsx
+++ b/src/pages/TangemClaimPage/TangemClaimPage.tsx
@@ -91,7 +91,7 @@ const ClaimShell: FC<{ phase: Phase; stepIndex: number; action: ReactNode; child
             {onboarding && (
               <p className={classes.intro}>
                 Bid at least 500 iKAS during ZAP? You’re in the draw for one of 10 Igra-themed
-                Tangem 3-card sets.
+                Tangem 2-card sets.
                 <br />
                 Connect your wallet to check, and optionally add an email so we can notify if you win.
               </p>

--- a/src/pages/TangemClaimPage/legalContent.tsx
+++ b/src/pages/TangemClaimPage/legalContent.tsx
@@ -44,8 +44,8 @@ export const GiveawayRules: FC = () => (
     <h3>2. Prizes</h3>
     <p>The Giveaway offers ten prizes.</p>
     <p>
-      Each prize consists of one Tangem Wallet three-card set, with an approximate retail value of
-      USD 63.
+      Each prize consists of one Tangem Wallet two-card set, with an approximate retail value of
+      USD 55.
     </p>
     <p>Prizes cannot be exchanged for cash, tokens or another product.</p>
 


### PR DESCRIPTION
Updates the giveaway prize on `/tangem-claim` from a Tangem Wallet **three-card set** to a **two-card set**, everywhere:

- **Intro copy** → "Igra-themed Tangem **2-card** sets"
- **Rules §2 Prizes** → "one Tangem Wallet **two-card** set, approximate retail value **USD 55**" (was USD 63 for the 3-card set)

Copy-only change (2 files). `yarn build` passes.

> Confirm USD 55 matches the intended prize value for the 2-card set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)