### PR TITLE
ecosystem: LYNX -> mainnet

### DIFF
--- a/src/Components/ProjectsList/ProjectsList.tsx
+++ b/src/Components/ProjectsList/ProjectsList.tsx
@@ -79,10 +79,10 @@ const projects: Project[] = [
   {
     logoUrl: lynx,
     name: 'LYNX',
-    description: 'LYNX is a liquid staking vault protocol on Igra, now on Galleon testnet. It lets anyone stake IGRA, the network\'s governance and security token, without running an Attester node, and earn staking rewards.',
+    description: 'LYNX is a liquid staking vault protocol on Igra, now on mainnet. It lets anyone stake IGRA, the network\'s governance and security token, without running an Attester node, and earn staking rewards.',
     to: 'https://lynx.kat.foundation/',
     type: 'DeFi, Liquid Staking',
-    badge: 'testnet',
+    badge: 'mainnet',
   },
 
   {


### PR DESCRIPTION
LYNX is now live on mainnet: updates its ecosystem card badge `testnet` -> `mainnet` and the description ("now on Galleon testnet" -> "now on mainnet"). Link unchanged (https://lynx.kat.foundation/).

Local `yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)