### PR TITLE
Tangem claim: registration-closed status

### DIFF
--- a/src/pages/TangemClaimPage/TangemClaimPage.module.scss
+++ b/src/pages/TangemClaimPage/TangemClaimPage.module.scss
@@ -99,6 +99,36 @@
     margin: 16px 0 0;
   }
 
+  .closedHeadline {
+    font-family: $font-secondary;
+    font-size: 30px;
+    line-height: 1.2;
+    font-weight: 400;
+    color: #FFFFFF;
+    margin: 0;
+  }
+
+  .closedText {
+    font-family: $font;
+    font-size: 18px;
+    line-height: 28px;
+    color: rgba(255, 255, 255, 0.7);
+    margin: 20px 0 0;
+  }
+
+  .closedLink {
+    align-self: flex-start;
+    margin: 24px 0 0;
+    font-family: $font;
+    font-size: 16px;
+    color: #6BD1C3;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
   // Compact horizontal step tracker: dot + label, connectors between.
   .tracker {
     list-style: none;
@@ -538,6 +568,14 @@
     }
 
     .intro {
+      font-size: 16px;
+    }
+
+    .closedHeadline {
+      font-size: 24px;
+    }
+
+    .closedText {
       font-size: 16px;
     }
 

--- a/src/pages/TangemClaimPage/TangemClaimPage.tsx
+++ b/src/pages/TangemClaimPage/TangemClaimPage.tsx
@@ -45,6 +45,10 @@ interface Verified {
 // (Rules + Privacy open in-page modals, see the footer.)
 const ELIGIBILITY_SNAPSHOT_URL = 'https://github.com/IgraLabs/tangem-zap-giveaway-2026'
 
+// The reproducible-draw writeup, linked from the closed-registration screen.
+const REPRODUCE_URL =
+  'https://github.com/IgraLabs/tangem-zap-giveaway-2026/blob/draw-v1.2/REPRODUCE.md'
+
 // The exact registration deadline, shown to the user verbatim.
 const DEADLINE = '15 August 2026, 23:59 UTC'
 
@@ -359,22 +363,102 @@ const TangemClaimInner: FC = () => {
   )
 }
 
-export const TangemClaimPage: FC = () => (
-  <PageLayout hideBg>
-    {isAppKitConfigured ? (
-      <TangemClaimProviders>
-        <TangemClaimInner />
-      </TangemClaimProviders>
-    ) : (
-      <ClaimShell
-        phase="connect"
-        stepIndex={0}
-        action={
-          <p className={classes.error}>
-            Wallet connection is not configured yet. Please check back soon.
-          </p>
-        }
-      />
-    )}
-  </PageLayout>
-)
+/**
+ * Post-registration status screen. Registration is closed; the precommitted draw
+ * is being verified and winners will be published here. Renders no wagmi/AppKit
+ * hooks, so there is no wallet connection (and no unsupported-network prompt).
+ */
+const ClaimClosed: FC = () => {
+  const [openDoc, setOpenDoc] = useState<'rules' | 'privacy' | null>(null)
+  return (
+    <div className={classes.root}>
+      <div className={classes.layout}>
+        <div className={classes.left}>
+          <h1 className={classes.title}>Igra × Tangem Giveaway</h1>
+
+          <div className={classes.card}>
+            <p className={classes.closedHeadline}>Registration is closed.</p>
+            <p className={classes.closedText}>
+              The precommitted Kaspa beacon and deterministic draw are now being independently
+              verified. 10 provisional winners will be published here once verification is complete.
+            </p>
+            <a
+              className={classes.closedLink}
+              href={REPRODUCE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View draw methodology ↗
+            </a>
+          </div>
+
+          <nav className={classes.footerLinks} aria-label="Giveaway documents">
+            <a href={ELIGIBILITY_SNAPSHOT_URL} target="_blank" rel="noopener noreferrer">
+              Eligibility snapshot
+            </a>
+            <span aria-hidden="true">·</span>
+            <button type="button" onClick={() => setOpenDoc('rules')}>
+              Giveaway rules
+            </button>
+            <span aria-hidden="true">·</span>
+            <button type="button" onClick={() => setOpenDoc('privacy')}>
+              Privacy notice
+            </button>
+          </nav>
+        </div>
+
+        <div className={classes.hero} aria-hidden="true">
+          <img src={heroImg} alt="" className={classes.heroImg} />
+        </div>
+      </div>
+
+      {openDoc === 'rules' && (
+        <LegalModal title={GIVEAWAY_RULES_TITLE} onClose={() => setOpenDoc(null)}>
+          <GiveawayRules />
+        </LegalModal>
+      )}
+      {openDoc === 'privacy' && (
+        <LegalModal title={PRIVACY_NOTICE_TITLE} onClose={() => setOpenDoc(null)}>
+          <PrivacyNotice />
+        </LegalModal>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Registration has closed, so the page shows the status screen. The interactive
+ * wallet flow (connect → SIWE → email) above is intentionally kept — it will be
+ * reused for winners' address registration. Flip REGISTRATION_CLOSED to re-enable it.
+ */
+const REGISTRATION_CLOSED: boolean = true
+
+export const TangemClaimPage: FC = () => {
+  if (REGISTRATION_CLOSED) {
+    return (
+      <PageLayout hideBg>
+        <ClaimClosed />
+      </PageLayout>
+    )
+  }
+
+  return (
+    <PageLayout hideBg>
+      {isAppKitConfigured ? (
+        <TangemClaimProviders>
+          <TangemClaimInner />
+        </TangemClaimProviders>
+      ) : (
+        <ClaimShell
+          phase="connect"
+          stepIndex={0}
+          action={
+            <p className={classes.error}>
+              Wallet connection is not configured yet. Please check back soon.
+            </p>
+          }
+        />
+      )}
+    </PageLayout>
+  )
+}


### PR DESCRIPTION
Registration for the Igra × Tangem giveaway has closed, so `/tangem-claim` now shows a static status instead of the wallet-connect flow:

- **"Registration is closed."** + the precommitted-beacon / deterministic-draw note ("10 provisional winners will be published here once verification is complete")
- A **View draw methodology ↗** link to the `REPRODUCE.md`
- Keeps the title, hero art, and Eligibility / Rules / Privacy footer (rules & privacy still open their modals)

The interactive wallet flow (connect → SIWE → email) is **kept intact**, gated behind a `REGISTRATION_CLOSED` flag — it will be reused for winners' address registration. Since the page no longer mounts the wallet connect, the unsupported-network ("Switch Network") prompt is gone too.

Local `yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
