### PR TITLE
News banner: draw complete — winners announced, connect to claim

### DIFF
--- a/src/Components/NewsBanner/NewsBanner.tsx
+++ b/src/Components/NewsBanner/NewsBanner.tsx
@@ -13,7 +13,7 @@ export const NewsBanner: FC = () => {
   return (
     <Link to={to.tangemClaim()} className={classes.root} onClick={handleClick}>
       <span className={classes.text}>
-        Igra × Tangem wallet giveaway is live! <strong>Check if you're eligible.</strong>
+        Igra × Tangem giveaway — winners announced! <strong>Connect your wallet to claim.</strong>
       </span>
     </Link>
   )


### PR DESCRIPTION
The Igra × Tangem draw is complete and `/tangem-claim` now shows the winners' claim flow (#121), so the site-wide top ribbon copy — *"…giveaway is live! Check if you're eligible."* — was stale (it links to "The draw is complete").

Updates the `NewsBanner` text to **"Igra × Tangem giveaway — winners announced! Connect your wallet to claim."** Link (`/tangem-claim`) and the `TangemGiveawayBannerClick` Plausible event are unchanged.

`yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)