### PR TITLE
Observability: Sentry error tracking + vesting-claim Plausible events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,13 @@ VITE_WALLETCONNECT_PROJECT_ID=
 # so VITE_GIVEAWAY_API_URL is still required. Mock code is always 123456.
 # Leave unset in production.
 VITE_GIVEAWAY_MOCK=
+
+# Sentry error reporting (optional). The DSN is a public client-side key — safe to
+# commit/embed. Error reporting is off when unset and on localhost. Set it per
+# Netlify context (production + deploy-preview) to catch prod/preview crashes.
+VITE_SENTRY_DSN=
+# Optional Sentry release id (e.g. commit SHA) for grouping errors by deploy.
+VITE_SENTRY_RELEASE=
+
+# PoolStakes (/igra-vesting) network profile: mainnet (default) | galleon | fork.
+VITE_POOLSTAKES_NETWORK=

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@gsap/react": "^2.1.2",
     "@reown/appkit": "^1.8.23",
     "@reown/appkit-adapter-wagmi": "^1.8.23",
+    "@sentry/react": "^10.71.0",
     "@tanstack/react-query": "^5.101.4",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,12 +1,57 @@
 import './global.scss'
 import './fonts/fonts.scss'
 
-import { FC } from "react"
+import * as Sentry from '@sentry/react'
+import { FC } from 'react'
 
 import { AppRouter } from './router'
 
-export const App: FC = () => {
-  return (
+/**
+ * Last-resort fallback when a render error escapes to the app root. Uses inline
+ * styles (no CSS-module dependency) so it always renders, even if the crash is
+ * style-related. Sentry.ErrorBoundary reports the error before showing this.
+ */
+const AppErrorFallback: FC = () => (
+  <div
+    style={{
+      minHeight: '100vh',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 16,
+      padding: 24,
+      textAlign: 'center',
+      background: '#0A0A0A',
+      color: '#fff',
+      fontFamily: 'system-ui, sans-serif',
+    }}
+  >
+    <h1 style={{ fontSize: 24, margin: 0 }}>Something went wrong</h1>
+    <p style={{ margin: 0, opacity: 0.7, maxWidth: 420 }}>
+      The page hit an unexpected error. Please reload — if it keeps happening, try again shortly.
+    </p>
+    <button
+      type="button"
+      onClick={() => window.location.reload()}
+      style={{
+        marginTop: 8,
+        padding: '12px 24px',
+        borderRadius: 12,
+        border: '1px solid rgba(255,255,255,0.2)',
+        background: 'transparent',
+        color: '#fff',
+        fontSize: 16,
+        cursor: 'pointer',
+      }}
+    >
+      Reload
+    </button>
+  </div>
+)
+
+export const App: FC = () => (
+  <Sentry.ErrorBoundary fallback={<AppErrorFallback />}>
     <AppRouter />
-  )
-}
+  </Sentry.ErrorBoundary>
+)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 
 import { App } from './app'
+import { initSentry } from './shared/lib/sentry'
+
+initSentry()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/PoolStakesPage/PoolStakesPage.tsx
+++ b/src/pages/PoolStakesPage/PoolStakesPage.tsx
@@ -15,6 +15,7 @@ import {
   waitForClaim,
   type Position,
 } from './client'
+import { errorReason, track, VestingEvent } from './analytics'
 import { CHAIN, TOKEN_SYMBOL } from './constants'
 import classes from './PoolStakesPage.module.scss'
 import { PoolStakesProviders } from './PoolStakesProviders'
@@ -187,9 +188,12 @@ const ConnectedApp: FC = () => {
       if (holderRef.current !== holder) return
       setPositions(next)
       setLoadError(null)
+      // Only on a foreground load (not the 12s poll), so counts aren't inflated.
+      if (!silent && next.length === 0) track(VestingEvent.NoAllocation)
     } catch (err) {
       if (holderRef.current !== holder) return
       setLoadError(describeError(err))
+      if (!silent) track(VestingEvent.LoadError, { reason: errorReason(err) })
     } finally {
       if (!silent) setLoading(false)
     }
@@ -222,14 +226,18 @@ const ConnectedApp: FC = () => {
         open()
         return
       }
+      track(VestingEvent.ClaimStart, { pool: key })
       setClaim(key, { status: 'submitting' })
       try {
         const hash = await claimAndWithdraw(walletClient, position.clone)
+        track(VestingEvent.ClaimSubmitted, { pool: key })
         setClaim(key, { status: 'pending', hash })
         await waitForClaim(hash)
+        track(VestingEvent.ClaimConfirmed, { pool: key })
         setClaim(key, { status: 'confirmed', hash })
         await refresh(true)
       } catch (err) {
+        track(VestingEvent.ClaimError, { pool: key, reason: errorReason(err) })
         setClaim(key, { status: 'error', message: describeError(err) })
       }
     },
@@ -237,6 +245,15 @@ const ConnectedApp: FC = () => {
   )
 
   const wrongNetwork = isConnected && chainId !== undefined && chainId !== CHAIN.id
+
+  // Funnel events: a wallet connected (once per connection), and connecting on the
+  // wrong chain — the two most common "can't claim" causes, visible in Plausible.
+  useEffect(() => {
+    if (isConnected && address) track(VestingEvent.Connected)
+  }, [isConnected, address])
+  useEffect(() => {
+    if (wrongNetwork) track(VestingEvent.WrongNetwork, { chainId: chainId ?? 0 })
+  }, [wrongNetwork, chainId])
 
   return (
     <div className={classes.root}>

--- a/src/pages/PoolStakesPage/analytics.ts
+++ b/src/pages/PoolStakesPage/analytics.ts
@@ -1,0 +1,47 @@
+/**
+ * Plausible custom events for the vesting claim funnel, so aggregate "can't claim"
+ * reasons are visible in the dashboard: wrong network, insufficient gas, rejected,
+ * dropped, no allocation, …
+ *
+ * PRIVACY: never put wallet addresses or PII in props — only low-cardinality
+ * categories (pool key, reason slug, chainId). That keeps it privacy-safe and is
+ * also what Plausible needs (it rejects/￼degrades on high-cardinality props).
+ *
+ * NOTE: each event name below must be added as a Goal in Plausible settings before
+ * it appears in the dashboard — Plausible only counts events registered as goals.
+ * On localhost `window.plausible` is undefined, so these all no-op in dev.
+ */
+
+type Props = Record<string, string | number | boolean>
+
+export function track(event: string, props?: Props): void {
+  try {
+    window.plausible?.(event, props ? { props } : undefined)
+  } catch {
+    /* analytics must never break the app */
+  }
+}
+
+/** Low-cardinality reason slug for a claim/load failure (safe as a Plausible prop). */
+export function errorReason(err: unknown): string {
+  const raw = (err instanceof Error ? err.message : String(err)).toLowerCase()
+  if (/user rejected|denied|rejected the request/.test(raw)) return 'rejected'
+  if (/nothing to withdraw/.test(raw)) return 'nothing'
+  if (/unknown stake/.test(raw)) return 'no-stake'
+  if (/insufficient funds|not enough ikas|exceeds the balance/.test(raw)) return 'insufficient-gas'
+  if (/timed out|not.*mined|receipt|drop/.test(raw)) return 'dropped'
+  if (/reach|network|connection|fetch/.test(raw)) return 'network'
+  return 'other'
+}
+
+/** Vesting-claim funnel event names (register these as Plausible goals). */
+export const VestingEvent = {
+  Connected: 'VestingWalletConnected',
+  WrongNetwork: 'VestingWrongNetwork',
+  NoAllocation: 'VestingNoAllocation',
+  LoadError: 'VestingLoadError',
+  ClaimStart: 'VestingClaimStart',
+  ClaimSubmitted: 'VestingClaimSubmitted',
+  ClaimConfirmed: 'VestingClaimConfirmed',
+  ClaimError: 'VestingClaimError',
+} as const

--- a/src/shared/lib/sentry.ts
+++ b/src/shared/lib/sentry.ts
@@ -1,0 +1,37 @@
+import * as Sentry from '@sentry/react'
+
+/**
+ * Sentry error reporting.
+ *
+ * No-ops without `VITE_SENTRY_DSN`, and on localhost — so local dev never spams
+ * the project. Error monitoring ONLY (no performance tracing, no session replay),
+ * to stay comfortably inside the free tier. `sendDefaultPii: false` — this app has
+ * wallet flows, so we never attach IP/user data.
+ *
+ * The DSN is a public client-side key (safe to embed); it lives in an env var so
+ * it can be set per Netlify context and left unset in dev.
+ */
+
+const DSN = import.meta.env.VITE_SENTRY_DSN
+
+function currentEnvironment(): string {
+  const host = window.location.hostname
+  if (host === 'igralabs.com' || host === 'www.igralabs.com') return 'production'
+  if (host.endsWith('.netlify.app')) return 'preview'
+  return 'development'
+}
+
+export function initSentry(): void {
+  if (!DSN) return
+  const host = window.location.hostname
+  if (host === 'localhost' || host === '127.0.0.1' || host === '') return
+
+  Sentry.init({
+    dsn: DSN,
+    environment: currentEnvironment(),
+    release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
+    // Error monitoring only — no tracing/replay (free-tier friendly).
+    tracesSampleRate: 0,
+    sendDefaultPii: false,
+  })
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -6,6 +6,12 @@ interface ImportMetaEnv {
   readonly VITE_WALLETCONNECT_PROJECT_ID?: string
   /** '1' to mock the email OTP endpoints for local frontend dev. */
   readonly VITE_GIVEAWAY_MOCK?: string
+  /** PoolStakes network profile: 'mainnet' (default) | 'galleon' | 'fork'. */
+  readonly VITE_POOLSTAKES_NETWORK?: string
+  /** Sentry DSN (public key). Error reporting is off when unset. */
+  readonly VITE_SENTRY_DSN?: string
+  /** Optional Sentry release identifier (e.g. commit SHA). */
+  readonly VITE_SENTRY_RELEASE?: string
 }
 
 interface ImportMeta {

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,70 @@
     "@noble/hashes" "~1.8.0"
     "@scure/base" "~1.2.5"
 
+"@sentry/browser-utils@10.71.0":
+  version "10.71.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser-utils/-/browser-utils-10.71.0.tgz#9d0e244a5d44d41df2740e8c25b7faf1edefc8eb"
+  integrity sha512-Djhb+RdEwSdYTlDaMzc2uRCA+bYDIFsFCtZzKEtB9UR7lJNV/bJ0k3el3ifaVGTRELO8WBll/X0elty1Dk5tTw==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.71.0"
+
+"@sentry/browser@10.71.0":
+  version "10.71.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-10.71.0.tgz#c290bfd245fc2501f9f615db6da287149d5594a5"
+  integrity sha512-fTE9tUDoggJSFv8cQ+h1UA9onovOoUNJWu8Var1MXmUVuVG/W3WqzJFVyKArZMj95lizZkq8aiS63SURvrBsFQ==
+  dependencies:
+    "@sentry/browser-utils" "10.71.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.71.0"
+    "@sentry/feedback" "10.71.0"
+    "@sentry/replay" "10.71.0"
+    "@sentry/replay-canvas" "10.71.0"
+
+"@sentry/conventions@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/conventions/-/conventions-0.16.0.tgz#3b58d15714cf44dca1518496c00749eec5525009"
+  integrity sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==
+
+"@sentry/core@10.71.0":
+  version "10.71.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-10.71.0.tgz#7b523ccef4700910cc66ef1edc3c19e833dcac6c"
+  integrity sha512-OIjT7rzcWJjUC6r3eBT3Td1j0afDBMkbbx9jTocSD+ZSfc25eEU7hoIPS0WvfeIOTIN3y8bfQnXavwMReaNVHQ==
+  dependencies:
+    "@sentry/conventions" "^0.16.0"
+
+"@sentry/feedback@10.71.0":
+  version "10.71.0"
+  resolved "https://registry.yarnpkg.com/@sentry/feedback/-/feedback-10.71.0.tgz#51db910419ac50137efbcdff406794f1856d700c"
+  integrity sha512-4+zMAmn1DcbYBtFE0pWt6zo8vWoBHTuP/UhtCMTCoGB4sVYvmwRxv9Hc9OpRHSzE9kSl8beD0zKFxuoVHizKQQ==
+  dependencies:
+    "@sentry/core" "10.71.0"
+
+"@sentry/react@^10.71.0":
+  version "10.71.0"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-10.71.0.tgz#93a40bb3f526f041d7c20ae0e2b081a1e33b3830"
+  integrity sha512-Ab1cFyOpl0PKKgEBlckIq/gCRIP/MD75gc4B85YnifdTAHK3KxgSWxz43GCeyTTyNBCx19XQsd0dti9YCRYCkw==
+  dependencies:
+    "@sentry/browser" "10.71.0"
+    "@sentry/conventions" "^0.16.0"
+    "@sentry/core" "10.71.0"
+
+"@sentry/replay-canvas@10.71.0":
+  version "10.71.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay-canvas/-/replay-canvas-10.71.0.tgz#15e87d9ed7af649e0d862dc6d43b308539c0d3bc"
+  integrity sha512-YTqesxBh9arExI49LrTm4Y2/xPX40q2GWi0gWRw6lNfYtyNz7/ZfHi8/1N6JEc8dldTslqFhII6ZFecUyU9iaA==
+  dependencies:
+    "@sentry/core" "10.71.0"
+    "@sentry/replay" "10.71.0"
+
+"@sentry/replay@10.71.0":
+  version "10.71.0"
+  resolved "https://registry.yarnpkg.com/@sentry/replay/-/replay-10.71.0.tgz#65fc0d7dee99cf5d36bd17bc9108ce3a6fb38a5d"
+  integrity sha512-ytEgVg7isvavQL6hgsgYeuSCkcA3EyOKm9lMLQOZTLkiUCtFT/ItWwGNhzS46vQ6wsTv3Uc0Y1JlcJHSFKe/Kg==
+  dependencies:
+    "@sentry/browser-utils" "10.71.0"
+    "@sentry/core" "10.71.0"
+
 "@solana-program/system@^0.10.0":
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/@solana-program/system/-/system-0.10.0.tgz#f68ffb0a3e1c1d5e68ecfe111fbbe729f95a582a"


### PR DESCRIPTION
Adds crash/error visibility and a "can't claim" debugging funnel.

## Sentry (site-wide)
- `@sentry/react`, initialised in `main.tsx` — **guarded by `VITE_SENTRY_DSN` and skipped on localhost**, so dev never spams the project. Error monitoring only (`tracesSampleRate: 0`, no replay) to stay in the **free tier**; `sendDefaultPii: false` (wallet app). `environment` derived from hostname → production / preview / development.
- Top-level **`Sentry.ErrorBoundary`** with a graceful inline fallback + Reload — a render crash no longer white-screens the whole SPA.
- DSN set on Netlify (production + deploy-preview contexts). The DSN is a public client-side key.

## Plausible funnel for `/igra-vesting`
So when an investor says "can't claim", you can see the aggregate reason in Plausible:
- Events: `VestingWalletConnected`, `VestingWrongNetwork`, `VestingNoAllocation`, `VestingLoadError`, `VestingClaimStart`, `VestingClaimSubmitted`, `VestingClaimConfirmed`, `VestingClaimError`.
- Each failure carries a low-cardinality **reason** slug (`rejected` / `insufficient-gas` / `dropped` / `no-stake` / `network` / `nothing` / `other`) + `pool` key. **No wallet addresses or PII** in props. Poll refreshes don't emit (foreground only), so counts aren't inflated.
- ⚠️ **These event names must be added as Goals in Plausible settings** to show up (Plausible only counts registered goals).

`yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)